### PR TITLE
Updating README to import from the GitHub URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please install [mbed CLI](https://github.com/ARMmbed/mbed-cli#installing-mbed-cl
 From the command line, import the example:
 
 ```
-mbed import mbed-os-example-blinky
+mbed import https://github.com/ARMmbed/mbed-os-example-blinky
 cd mbed-os-example-blinky
 ```
 


### PR DESCRIPTION
The previous instructions didn't work if you cloned the project locally with git and then ran the commands. The changes instruct the user to now import the program through mbed CLI via the GitHub URL.
