### PR TITLE
Remove the note about wait

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,6 @@
 DigitalOut led1(LED1);
 
 // main() runs in its own thread in the OS
-// (note the calls to wait below for delays)
 int main() {
     while (true) {
         led1 = !led1;


### PR DESCRIPTION
This was only relevant when we were using `Thread::wait` and this sentence was used to emphasize that we were running in our own thread. Not needed anymore now that we use `wait()`.

@AnotherButler 