### PR TITLE
mbed OS 5.4

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5faf4b26c5954d15c7c1cccac6498e0c690ad101
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff


### PR DESCRIPTION
Update to the latest mbed OS release. Will be squashed as it does not contain any relevant changes besides lib update.