### PR TITLE
Changed git commit to align with mbed os5.6 release tag

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#afffea9a848b443796d952cb406206f1a6f8d257
+https://github.com/ARMmbed/mbed-os/#a4056fb8bf3ee10b8e037d332f8fbd0c68169ef1


### PR DESCRIPTION
The older mbed-os.lib seemed to point to the wrong commit, according to the [mbed-os 5.6.0-rc release tag](https://github.com/ARMmbed/mbed-os/releases). Changing this to #a4056fb8bf3ee10b8e037d332f8fbd0c68169ef1 to align with tag.