### PR TITLE
Add printout to every 10th print

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Image: .\.build\K64F\ARM\mbed-os-example-blinky.bin
 
 The LED on your platform turns on and off.
 
+## Serial port output
+
+The program does also print the blink count for every 10th blink. If you want to see the printout, please see the (Mbed OS instructions for serial)[https://os.mbed.com/docs/v5.6/tutorials/serial-communication.html].
+
 ## Export the project to Keil MDK, and debug your application
 
 From the command-line, run the following command:
@@ -85,3 +89,10 @@ To debug the application:
  ```
 
 2. If using Keil MDK, make sure you have a license installed. [MDK-Lite](http://www.keil.com/arm/mdk.asp) has a 32 KB restriction on code size.
+
+# Board specific information
+
+## Realtek RTL8195AM
+
+This board does not have any LEDs connected to the main MCU, all the LEDs are connected to the DAPLINK host CPU. Therefore, for the board to work one has to connect an LED directly to <need to specify where!>.
+

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,18 @@
+#include <inttypes.h>
 #include "mbed.h"
 
 DigitalOut led1(LED1);
 
 // main() runs in its own thread in the OS
 int main() {
+    uint32_t ctr = 0;
+
+    printf("Starting mbed-os-example-blinky\n");
     while (true) {
+        ctr++;
+        if (ctr % 10 == 0) {
+            printf("%" PRIu32 " blinks\n", ctr);
+        }
         led1 = !led1;
         wait(0.5);
     }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,0 +1,8 @@
+{
+    "target_overrides": {
+        "*": {
+            "platform.stdio-baud-rate": 1152000,
+            "platform.stdio-convert-newlines": true
+        }
+    }
+}

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,7 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-baud-rate": 1152000,
+            "platform.stdio-baud-rate": 9600,
             "platform.stdio-convert-newlines": true
         }
     }


### PR DESCRIPTION
Add a starting print and print for every 10 blinks, so that you can
monitor in a CI job if the app is running normally.