### PR TITLE
Revert RAM/ROM reporting segment, went in after 5.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,6 @@ Mbed OS Version: 999999
 CPU ID: 0x410fc241
 Compiler ID: 2
 Compiler Version: 60300
-RAM0: Start 0x20000000 Size: 0x30000
-RAM1: Start 0x1fff0000 Size: 0x10000
-ROM0: Start 0x0 Size: 0x100000
 ================= CPU STATS =================
 Idle: 98% Usage: 2%
 ================ HEAP STATS =================

--- a/stats_report.h
+++ b/stats_report.h
@@ -41,17 +41,6 @@ public:
         printf("CPU ID: 0x%lx \r\n", sys_stats.cpu_id);
         printf("Compiler ID: %d \r\n", sys_stats.compiler_id);
         printf("Compiler Version: %ld \r\n", sys_stats.compiler_version);
-
-        for (int i = 0; i < MBED_MAX_MEM_REGIONS; i++) {
-            if (sys_stats.ram_size[i] != 0) {
-                printf("RAM%d: Start 0x%lx Size: 0x%lx \r\n", i, sys_stats.ram_start[i], sys_stats.ram_size[i]);
-            }
-        }
-        for (int i = 0; i < MBED_MAX_MEM_REGIONS; i++) {
-            if (sys_stats.rom_size[i] != 0) {
-                printf("ROM%d: Start 0x%lx Size: 0x%lx \r\n", i, sys_stats.rom_start[i], sys_stats.rom_size[i]);
-            }
-        }
     }
 
     ~SystemReport(void)


### PR DESCRIPTION
Reverting 5.11 features from last PR.

@cmonr 