### PR TITLE
Add contributing references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing to Mbed OS
+
+Mbed OS is an open-source, device software platform for the Internet of Things. Contributions are an important part of the platform, and our goal is to make it as simple as possible to become a contributor.
+
+To encourage productive collaboration, as well as robust, consistent and maintainable code, we have a set of guidelines for [contributing to Mbed OS](https://os.mbed.com/docs/latest/reference/contributing.html).

--- a/README.md
+++ b/README.md
@@ -162,3 +162,9 @@ If you have problems, you can review the [documentation](https://os.mbed.com/doc
 * [Mbed OS Stats API](https://os.mbed.com/docs/latest/apis/mbed-statistics.html)
 * [Mbed OS Configuration](https://os.mbed.com/docs/latest/reference/configuration.html)
 * [Mbed OS Serial Communication](https://os.mbed.com/docs/latest/tutorials/serial-communication.html)
+
+### License and contributions
+
+The software is provided under Apache-2.0 license. Contributions to this project are accepted under the same license. Please see contributing.md for more info.
+
+This project contains code from other projects. The original license text is included in those source files. They must comply with our license guide.


### PR DESCRIPTION
Merge after 5.11 oob branch is in

Similar to what we have in Mbed OS

This adds:

- inbound-outbound license model
- specifies the license
- adds contributing info (links to our contributing guide)