### PR TITLE
Set the baudrate to default and reduce prints in blinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,7 @@ You can view individual examples and additional API information of the statistic
 
 ### Output
 
-To view the serial output you can use any terminal client of your choosing such as [PuTTY](http://www.putty.org/) or [CoolTerm](http://freeware.the-meiers.org/).
-
-The default baud rate for this application is set to `115200` and may be modified in the `mbed_app.json` file.
+To view the serial output you can use any terminal client of your choosing such as [PuTTY](http://www.putty.org/) or [CoolTerm](http://freeware.the-meiers.org/). Unless otherwise specified, printf defaults to a baud rate of 9600 on Mbed OS.
 
 You can find more information on the Mbed OS configuration tools and serial communication in Mbed OS in the related [related links section](#related-links).
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,17 +8,25 @@
 
 DigitalOut led1(LED1);
 
+#define SLEEP_TIME                  500 // (msec)
+#define PRINT_AFTER_N_LOOPS         20
+
 // main() runs in its own thread in the OS
 int main()
 {
-    SystemReport sys_state(500 /* Loop delay time in ms */);
+    SystemReport sys_state( SLEEP_TIME * PRINT_AFTER_N_LOOPS /* Loop delay time in ms */);
 
+    int count = 0;
     while (true) {
         // Blink LED and wait 0.5 seconds
         led1 = !led1;
-        wait_ms(500);
+        wait_ms(SLEEP_TIME);
 
-        // Following the main thread wait, report on the current system status
-        sys_state.report_state();
+        if ((0 == count) || (PRINT_AFTER_N_LOOPS == count)) {
+            // Following the main thread wait, report on the current system status
+            sys_state.report_state();
+            count = 0;
+        }
+        ++count;
     }
 }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,6 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-baud-rate": 115200,
             "platform.stack-stats-enabled": true,
             "platform.heap-stats-enabled": true,
             "platform.cpu-stats-enabled": true,


### PR DESCRIPTION
Issue: https://github.com/ARMmbed/mbed-os-example-blinky/issues/153