### PR TITLE
CMake: Do not include the removed mbed-os/cmake/app.cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,18 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-# Mbed OS system root path - that probably needs to come from tools
-# TODO: @mbed-os-tools
+# TODO: @mbed-os-tools MBED_ROOT and MBED_CONFIG_PATH should probably come from mbedtools
 set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-blinky)
 
 add_subdirectory(${MBED_ROOT})
 
-project(${APP_TARGET})
+add_executable(${APP_TARGET})
 
-option(VERBOSE_BUILD "Have a verbose build process")
-if(VERBOSE_BUILD)
-    set(CMAKE_VERBOSE_MAKEFILE ON)
-endif()
+mbed_os_target_linker_script(${APP_TARGET})
+
+project(${APP_TARGET})
 
 target_sources(${APP_TARGET}
     PRIVATE
@@ -24,3 +22,10 @@ target_sources(${APP_TARGET}
 )
 
 target_link_libraries(${APP_TARGET} mbed-os)
+
+mbed_os_bin_hex(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13)
@@ -5,14 +6,21 @@ cmake_minimum_required(VERSION 3.13)
 # Mbed OS system root path - that probably needs to come from tools
 # TODO: @mbed-os-tools
 set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET mbed-os-example-blinky)
 
-# Include standard Mbed definitions
-include(${MBED_ROOT}/cmake/app.cmake)
+add_subdirectory(${MBED_ROOT})
 
-project(mbed-os-example-blinky)
+project(${APP_TARGET})
 
-# uncomment below to have a verbose build process
-#set(CMAKE_VERBOSE_MAKEFILE ON)
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()
 
-# Sources for main application
-target_sources(app PRIVATE main.cpp)
+target_sources(${APP_TARGET}
+    PRIVATE
+        main.cpp
+)
+
+target_link_libraries(${APP_TARGET} mbed-os)


### PR DESCRIPTION
The module has been removed in mbed-os. Add the mbed-os
sub-directory instead to process its `CMakeLists.txt` source
file.
This commit also set the name of the executable target to match
the project name.

Test with: https://github.com/ARMmbed/mbed-os/pull/13378
