### PR TITLE
CMake: Call function to setup the application target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ add_subdirectory(${MBED_ROOT})
 
 add_executable(${APP_TARGET})
 
+mbed_os_configure_app_target(${APP_TARGET})
+
 mbed_os_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})


### PR DESCRIPTION
The application target can only be configured from
where it has been created. Thus it needs to call the provided
function to apply settings required by Mbed OS.

Depends on: https://github.com/ARMmbed/mbed-os/pull/13413