### PR TITLE
CMake: Use `mbed_` prefix for CMake functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ add_subdirectory(${MBED_ROOT})
 
 add_executable(${APP_TARGET})
 
-mbed_os_configure_app_target(${APP_TARGET})
+mbed_configure_app_target(${APP_TARGET})
 
-mbed_os_target_linker_script(${APP_TARGET})
+mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 
@@ -25,7 +25,7 @@ target_sources(${APP_TARGET}
 
 target_link_libraries(${APP_TARGET} mbed-os)
 
-mbed_os_bin_hex(${APP_TARGET})
+mbed_generate_bin_hex(${APP_TARGET})
 
 option(VERBOSE_BUILD "Have a verbose build process")
 if(VERBOSE_BUILD)


### PR DESCRIPTION
Replace the prefix `mbed_os`_ with the `mbed_` as it is the one used throughout Mbed OS.

Depends on: https://github.com/ARMmbed/mbed-os/pull/13421