### PR TITLE
Update for mbed-os-6.3.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849
+https://github.com/ARMmbed/mbed-os/#0db72d0cf26539016efbe38f80d6f2cb7a3d4414


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.3.0 release of mbed-os. 