### PR TITLE
Document RTOS requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ You can build the project with all supported [Mbed OS build tools](https://os.mb
 
 The `main()` function is the single thread in the application. It toggles the state of a digital output connected to an LED on the board.
 
+**Note**: This example requires a target with RTOS support, i.e. one with `rtos` declared in `supported_application_profiles` in `targets/targets.json` in [mbed-os](https://github.com/ARMmbed/mbed-os). For non-RTOS targets (usually with small memory sizes), please use [mbed-os-example-blinky-baremetal](https://github.com/ARMmbed/mbed-os-example-blinky-baremetal) instead.
+
 ## Building and running
 
 1. Connect a USB cable between the USB port on the board and the host computer.


### PR DESCRIPTION
Fixes: https://github.com/ARMmbed/mbed-os/issues/13106

This example (mbed-os-example-blinky) requires targets with RTOS support. Bare-metal-targets generally do not have enough memories for this. This PR documents it in README.