### PR TITLE
CMake: Call mbed_set_post_build API for setting post build operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,8 @@ matrix:
         - >-
           git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git;
         - >-
-          mbedtools configure -t GCC_ARM -m ${TARGET_NAME};
-          mkdir -p build
       script:
-        - cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=${PROFILE} && cmake --build .
+        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *cmake-build-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
         - pip install --upgrade mbed-tools
         # Fetch mbed-os: We use manual clone, with depth=1 and --single-branch to save time.
         - >-
-          git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git;
+          git clone --depth=1 --branch feature-cmake https://github.com/ARMmbed/mbed-os.git;
         - >-
       script:
         - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ language: sh
 os: linux
 dist: xenial
 
+env:
+  global:
+    - PROFILE=develop
+
 cache:
   pip: true
   ccache: true
@@ -28,8 +32,13 @@ cache:
 
 addons:
   apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
     packages:
-    - ninja-build
+      - cmake
+      - ninja-build
 
 matrix:
   include:
@@ -56,13 +65,21 @@ matrix:
         - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
         - popd
         - arm-none-eabi-gcc --version
-        - pip install --upgrade cmake
+        # Hide Travis-preinstalled CMake
+        # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+        # can't replace it with an apt-supplied version very easily. Additionally, we
+        # can't permit the Travis-preinstalled copy to survive, as the Travis default
+        # path lists the Travis CMake install location ahead of any place where apt
+        # would install CMake to. Instead of apt removing or upgrading to a new CMake
+        # version, we must instead delete the Travis copy of CMake.
+        - sudo rm -rf /usr/local/cmake*
         - pip install --upgrade mbed-tools
         # Fetch mbed-os: We use manual clone, with depth=1 and --single-branch to save time.
         - >-
           git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git;
         - >-
       script:
+        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,15 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.18.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
-# TODO: @mbed-os-tools MBED_ROOT and MBED_CONFIG_PATH should probably come from mbedtools
-set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-blinky)
 
-include(${MBED_ROOT}/tools/cmake/app.cmake)
+include(${MBED_PATH}/tools/cmake/app.cmake)
 
-add_subdirectory(${MBED_ROOT})
+add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(${APP_TARGET}
         mbed-os
 )
 
-mbed_generate_bin_hex(${APP_TARGET})
+mbed_set_post_build(${APP_TARGET})
 
 option(VERBOSE_BUILD "Have a verbose build process")
 if(VERBOSE_BUILD)


### PR DESCRIPTION
- Called mbed_set_post_build API for setting post-build operations