### PR TITLE
travis: Update mbedtools `build` to `compile`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,8 @@ matrix:
           git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git;
         - >-
       script:
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *cmake-build-test


### PR DESCRIPTION
In the latest release of Mbed CLI 2 - 4.0.0 the command option has been
changed to ensure good usability.

The `build` command option is been changed to `compile` by keeping
the existing functionality.

Please merge after new Mbedtools release. 