### PR TITLE
Update for mbed-os-6.6.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783
+https://github.com/ARMmbed/mbed-os/

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#d6784c3ee6ada8e886801d0197904d3ab94c891c


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.6.0 release of mbed-os. 