### PR TITLE
ACI: prevent compilation error for targets without any LED

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,11 @@
 int main()
 {
     // Initialise the digital pin LED1 as an output
+#ifdef LED1
     DigitalOut led(LED1);
+#else
+    bool led;
+#endif
 
     while (true) {
         led = !led;


### PR DESCRIPTION
During mbed-os ACI, mbed-os-example-blinky is the basic application compiled for patch validation.

Some targets doesn't have any LED.
Goal is to avoid any specific action for these target validation, this PR will make build OK, and indicate a warning (which can be tracked).

@MarceloSalazar 

NB: this respects https://os.mbed.com/docs/mbed-os/v6.12/apis/standard-pin-names.html
